### PR TITLE
add cadence flexibility feature

### DIFF
--- a/deeplenstronomy/utils.py
+++ b/deeplenstronomy/utils.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import yaml
 
 from astropy.io import fits
 import numpy as np
@@ -303,3 +304,22 @@ def organize_image_backgrounds(im_dir, image_bank_size, config_dicts, configurat
 
     return image_indices
     
+
+def read_cadence_file(filename):
+    """
+    Parse a cadence file.
+
+    Args:
+        filename (str): Name of cadence file
+
+    Returns:
+        cadence_dict: dictionary containing cadence file contents
+    """
+    with open(filename, 'r') as f:
+        cadence_dict = yaml.safe_load(f)        
+        
+        # Set reference mjd to the default value of 0
+        if 'REFERENCE_MJD' not in cadence_dict:
+            cadence_dict['REFERENCE_MJD'] = 0
+                        
+    return cadence_dict


### PR DESCRIPTION
In response to Issue #47 . Users can now either set the NITES values to a list of nites to obtain time series observations (previous behavior) or can specify the name of a cadence file with the following format:

```
REFERENCE_MJD: 1 # default = 0
POINTING_1:
    g: [4, 5, 6, 8]  # must all be the same length
    r: [4, 5, 7, 8]
    i: [4, 6, 9, 11]
    z: [4, 5, 8, 10]
POINTING_2:
    g: [3, 5, 6]  # must all be the same length
    r: [3, 5, 7]
    i: [3, 6, 9]
    z: [3, 5, 8]
POINTING_3: ...
```

Each system is generated with a POINTING chosen at random, and the pointing can specify any cadence